### PR TITLE
Rename strcasestr to nullhttpd_strcasestr

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -273,7 +273,7 @@ int cgi_main()
 	}
 	conn[sid].dat->out_headdone=1;
 	conn[sid].dat->out_status=200;
-	if (strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
+	if (nullhttpd_strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.1");
 	} else {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.0");

--- a/src/format.c
+++ b/src/format.c
@@ -92,7 +92,7 @@ void swapchar(char *string, char oldchar, char newchar)
 	}
 }
 
-char *strcasestr(const char *src, const char *query)
+char *nullhttpd_strcasestr(const char *src, const char *query)
 {
 	char *pToken;
 	char Buffer[8192];

--- a/src/http.c
+++ b/src/http.c
@@ -238,7 +238,7 @@ void send_fileheader(int sid, int cacheable, int status, char *title, char *extr
 	} else {
 		conn[sid].dat->out_status=200;
 	}
-	if (strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
+	if (nullhttpd_strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.1");
 	} else {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.0");
@@ -249,7 +249,7 @@ void send_fileheader(int sid, int cacheable, int status, char *title, char *extr
 		snprintf(conn[sid].dat->out_Connection, sizeof(conn[sid].dat->out_Connection)-1, "Close");
 	}
 	// Nutscrape and Mozilla don't know what a fucking keepalive is
-	if ((strcasestr(conn[sid].dat->in_UserAgent, "MSIE")==NULL)) {
+	if ((nullhttpd_strcasestr(conn[sid].dat->in_UserAgent, "MSIE")==NULL)) {
 		snprintf(conn[sid].dat->out_Connection, sizeof(conn[sid].dat->out_Connection)-1, "Close");
 	}
 	prints("%s %d OK\r\n", conn[sid].dat->out_Protocol, conn[sid].dat->out_status);

--- a/src/nullhttpd.h
+++ b/src/nullhttpd.h
@@ -275,7 +275,7 @@ void fixslashes(char *pOriginal);
 int hex2int(char *pChars);
 void striprn(char *string);
 void swapchar(char *string, char oldchar, char newchar);
-char *strcasestr(const char *src, const char *query);
+char *nullhttpd_strcasestr(const char *src, const char *query);
 char *strcatf(char *dest, const char *format, ...);
 int printhex(const char *format, ...);
 int printht(const char *format, ...);

--- a/src/server.c
+++ b/src/server.c
@@ -113,10 +113,10 @@ logdata("\n[[[ FLUSHING HEADER ]]]\n");
 		snprintf(conn[sid].dat->out_Connection, sizeof(conn[sid].dat->out_Connection)-1, "Close");
 	}
 	// Nutscrape and Mozilla don't know what a fucking keepalive is
-	if ((strcasestr(conn[sid].dat->in_UserAgent, "MSIE")==NULL)) {
+	if ((nullhttpd_strcasestr(conn[sid].dat->in_UserAgent, "MSIE")==NULL)) {
 		snprintf(conn[sid].dat->out_Connection, sizeof(conn[sid].dat->out_Connection)-1, "Close");
 	}
-	if (strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
+	if (nullhttpd_strcasestr(conn[sid].dat->in_Protocol, "HTTP/1.1")!=NULL) {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.1");
 	} else {
 		snprintf(conn[sid].dat->out_Protocol, sizeof(conn[sid].dat->out_Protocol)-1, "HTTP/1.0");
@@ -556,7 +556,7 @@ unsigned htloop(void *x)
 //		}
 		conn[sid].dat->out_bodydone=1;
 		flushbuffer(sid);
-		if (strcasestr(conn[sid].dat->out_Connection, "close")!=NULL) break;
+		if (nullhttpd_strcasestr(conn[sid].dat->out_Connection, "close")!=NULL) break;
 	}
 	closeconnect(sid, 0);
 	logaccess(4, "Closing [%u][%u]", conn[sid].id, conn[sid].socket);


### PR DESCRIPTION
The strcasestr function has the same name as the strcasestr function
from the standard C library.  Rename it so that it does not conflict
with the standard C library function.